### PR TITLE
Door General Fix

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -3,4 +3,10 @@
   <component name="CompilerConfiguration">
     <bytecodeTargetLevel target="17" />
   </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_STRING" value="-AoutRefMapFile=C:\Users\Alex\IdeaProjects\Locks-Reforked\build\classes\java\main\locks.refmap.json -AdefaultObfuscationEnv=named:intermediary -Aquiet=true -AoutMapFileNamedIntermediary=C:\Users\Alex\IdeaProjects\Locks-Reforked\build\loom-cache\mixin-map-loom.mappings.1_20_1.layered+hash.2198-v2.main.tiny -AinMapFileNamedIntermediary=C:\Users\Alex\.gradle\caches\fabric-loom\1.20.1\loom.mappings.1_20_1.layered+hash.2198-v2\mappings.tiny" />
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="Locks-Reforked.test" options="-AoutRefMapFile=C:\Users\Alex\IdeaProjects\Locks-Reforked\build\classes\java\test\test-locks.refmap.json -AdefaultObfuscationEnv=named:intermediary -Aquiet=true -AoutMapFileNamedIntermediary=C:\Users\Alex\IdeaProjects\Locks-Reforked\build\loom-cache\mixin-map-loom.mappings.1_20_1.layered+hash.2198-v2.test.tiny -AinMapFileNamedIntermediary=C:\Users\Alex\.gradle\caches\fabric-loom\1.20.1\loom.mappings.1_20_1.layered+hash.2198-v2\mappings.tiny" />
+    </option>
+  </component>
 </project>

--- a/src/main/java/melonslise/locks/common/event/LocksEvents.java
+++ b/src/main/java/melonslise/locks/common/event/LocksEvents.java
@@ -47,34 +47,78 @@ import net.minecraft.world.level.chunk.LevelChunk;
 import java.util.Arrays;
 import java.util.Optional;
 
-
 public final class LocksEvents
 {
 	public static final Component LOCKED_MESSAGE = Component.translatable(Locks.ID + ".status.locked");
 
 	private LocksEvents() {}
 
-
-
 	public static void onLootTableLoad(ResourceManager resourceManager, LootDataManager lootManager, ResourceLocation id, LootTable.Builder tableBuilder, LootTableSource source)
 	{
 		// Only modify if it was a vanilla chest loot table
-
-        if (!id.getNamespace().equals("minecraft") || !id.getPath().startsWith("chests"))
+		if (!id.getNamespace().equals("minecraft") || !id.getPath().startsWith("chests"))
 			return;
 		// And only if there is a corresponding inject table...
 		ResourceLocation injectLoc = new ResourceLocation(Locks.ID, "loot_tables/inject/" + id.getPath() + ".json");
 		if (LocksUtil.resourceManager.getResource(injectLoc).isEmpty())
 			return;
 		// todo (kota): bring back
-
 	}
-
 
 	public static InteractionResult onRightClick(Player player, Level world, InteractionHand hand, BlockHitResult result)
 	{
-		//Gets the lock being interacted with and the handler
 		BlockPos pos = result.getBlockPos();
+
+		// NUEVO: Verificación temprana para puertas bloqueadas
+		if (LocksUtil.locked(world, pos)) {
+			BlockState state = world.getBlockState(pos);
+			// Si es una puerta y está bloqueada, maneja la interacción aquí directamente
+			if (state.getBlock() instanceof net.minecraft.world.level.block.DoorBlock) {
+				ILockableHandler handler = LocksComponents.LOCKABLE_HANDLER.get(world);
+				Lockable[] intersect = handler.getInChunk(pos).values().stream()
+						.filter(lkb -> lkb.bb.intersects(pos))
+						.toArray(Lockable[]::new);
+
+				if (intersect.length > 0) {
+					if(hand != InteractionHand.MAIN_HAND) return InteractionResult.FAIL;
+
+					Optional<Lockable> locked = Arrays.stream(intersect)
+							.filter(LocksPredicates.LOCKED)
+							.findFirst();
+
+					if (locked.isPresent()) {
+						Lockable lkb = locked.get();
+						ItemStack stack = player.getItemInHand(hand);
+
+						// Maneja el unlock/shake aquí
+						if (!canUnlock(lkb, stack, player)) {
+							lkb.swing(20);
+							world.playSound(player, pos, LocksSoundEvents.LOCK_RATTLE, SoundSource.BLOCKS, 1f, 1f);
+							player.swing(InteractionHand.MAIN_HAND);
+							return InteractionResult.FAIL; // Importante: FAIL evita que la puerta se abra
+						}
+
+						// Si puede desbloquear y está agachado
+						if (player.isShiftKeyDown() && hasMatchingKey(lkb, stack, player)) {
+							lkb.lock.setLocked(!lkb.lock.isLocked());
+							world.playSound(player, pos, LocksSoundEvents.LOCK_OPEN, SoundSource.BLOCKS, 1f, 1f);
+
+							if (!world.isClientSide) {
+								((ServerLevel) world).getServer().execute(() -> {
+									LocksComponents.LOCKABLE_HANDLER.sync(world);
+									(world.getChunk(pos)).setUnsaved(true);
+								});
+							}
+							return InteractionResult.SUCCESS;
+						}
+
+						return InteractionResult.FAIL; // Evita que la puerta se abra
+					}
+				}
+			}
+		}
+
+		//Gets the lock being interacted with and the handler
 		ILockableHandler handler = LocksComponents.LOCKABLE_HANDLER.get(world);
 		Lockable[] intersect = handler.getInChunk(pos).values().stream()
 				.filter(lkb -> lkb.bb.intersects(pos))
@@ -130,8 +174,6 @@ public final class LocksEvents
 
 			// Avoids rendering when it is opened with a key while standing
 			if(!lkb.isSmart() && player.isShiftKeyDown() && hasMatchingKey(lkb, stack, player)) { return InteractionResult.PASS; }
-
-
 
 			if(canUnlock(lkb,stack,player) && !hasMatchingKey(lkb, stack, player)) {
 				player.openMenu(new LockPickingContainer.Provider(hand, lkb));
@@ -192,7 +234,6 @@ public final class LocksEvents
 		return false;
 	}
 
-
 	public static boolean canBreakLockable(Level world,Player player, BlockPos pos)
 	{
 		return (LocksServerConfig.PROTECT_LOCKABLES.get() &&
@@ -202,7 +243,7 @@ public final class LocksEvents
 
 	public static boolean onBlockBreaking(Level world, Player player, BlockPos pos, BlockState state,@Nullable BlockEntity entity)
 	{
-        return !canBreakLockable(world,player, pos);
+		return !canBreakLockable(world,player, pos);
 	}
 
 	public static void onBlockBreak(Level world, Player player, BlockPos pos, BlockState state,@Nullable BlockEntity entity)
@@ -219,5 +260,4 @@ public final class LocksEvents
 		PlayerBlockBreakEvents.AFTER.register(LocksEvents::onBlockBreak);
 		UseBlockCallback.EVENT.register(LocksEvents::onRightClick);
 	}
-
 }

--- a/src/main/java/melonslise/locks/mixin/DoorMixin.java
+++ b/src/main/java/melonslise/locks/mixin/DoorMixin.java
@@ -2,20 +2,39 @@ package melonslise.locks.mixin;
 
 import melonslise.locks.common.util.LocksUtil;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.DoorBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(DoorBlock.class)
 public class DoorMixin {
-    @Inject(method = "setOpen", at = @At(value = "HEAD"), cancellable = true)
-    private void cancelOpen(Entity pEntity, Level pLevel, BlockState pState, BlockPos pPos, boolean pOpen, CallbackInfo ci){
-        if (LocksUtil.locked(pLevel, pPos)){
+
+    // Intercepta el método use() que se ejecuta ANTES del procesamiento de apertura
+    @Inject(method = "use", at = @At("HEAD"), cancellable = true)
+    private void preventUseWhenLocked(BlockState pState, Level pLevel, BlockPos pPos,
+                                      Player pPlayer, InteractionHand pHand, BlockHitResult pHit,
+                                      CallbackInfoReturnable<InteractionResult> cir) {
+        // Si la puerta está bloqueada, cancelamos el use() completamente
+        // Pero dejamos que LocksEvents maneje la lógica completa
+        if (LocksUtil.locked(pLevel, pPos)) {
+            cir.setReturnValue(InteractionResult.PASS); // PASS permite que LocksEvents procese
+        }
+    }
+
+    // Mantén este como respaldo para casos edge (redstone, pistons, etc)
+    @Inject(method = "setOpen", at = @At("HEAD"), cancellable = true)
+    private void cancelOpen(Entity pEntity, Level pLevel, BlockState pState, BlockPos pPos, boolean pOpen, CallbackInfo ci) {
+        if (LocksUtil.locked(pLevel, pPos)) {
             ci.cancel();
         }
     }

--- a/src/main/java/melonslise/locks/mixin/ServerWorldMixin.java
+++ b/src/main/java/melonslise/locks/mixin/ServerWorldMixin.java
@@ -1,6 +1,5 @@
 package melonslise.locks.mixin;
 
-import melonslise.locks.Locks;
 import melonslise.locks.common.components.interfaces.ILockableHandler;
 import melonslise.locks.common.config.LocksConfig;
 import melonslise.locks.common.init.LocksComponents;
@@ -15,29 +14,36 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.stream.Collectors;
-
 @Mixin(ServerLevel.class)
-public class ServerWorldMixin
-{
+public class ServerWorldMixin {
+
 	@Inject(at = @At("HEAD"), method = "sendBlockUpdated")
-	private void sendBlockUpdated(BlockPos pos, BlockState oldState, BlockState newState, int flag, CallbackInfo ci)
-	{
+	private void sendBlockUpdated(BlockPos pos, BlockState oldState, BlockState newState, int flag, CallbackInfo ci) {
+		// 1. If the block type itself hasn't changed (e.g., door opening/closing), skip dropping locks
+		if (oldState.getBlock() == newState.getBlock()) {
+			return;
+		}
+		// 2. Maintain previous behavior: skip if both blocks are recognized lockable types
 		if (LocksConfig.matchString(oldState.getBlock()) && LocksConfig.matchString(newState.getBlock())) {
 			return;
 		}
+
+		// Proceed with dropping locks for actual block replacements or removals
 		ServerLevel world = (ServerLevel) (Object) this;
 		ILockableHandler handler = LocksComponents.LOCKABLE_HANDLER.get(world);
-		// create buffer list because otherwise we will be deleting elements while iterating (BAD!!)
-		handler.getInChunk(pos).values().stream().filter(lkb -> lkb.bb.intersects(pos)).toList().forEach(lkb ->
-		{
-			world.playSound(null, pos, SoundEvents.IRON_DOOR_OPEN, SoundSource.BLOCKS, 0.8f, 0.8f + world.random.nextFloat() * 0.4f);
-			world.addFreshEntity(new ItemEntity(world, pos.getX() + 0.5d, pos.getY() + 0.5d, pos.getZ() + 0.5d, lkb.stack));
-			handler.remove(lkb.id);
-		});
-
-
-
-
+		handler.getInChunk(pos).values().stream()
+				.filter(lkb -> lkb.bb.intersects(pos))
+				.toList()
+				.forEach(lkb -> {
+					// Play sound and drop the lock item
+					world.playSound(null, pos, SoundEvents.IRON_DOOR_OPEN, SoundSource.BLOCKS, 0.8f,
+							0.8f + world.random.nextFloat() * 0.4f);
+					world.addFreshEntity(new ItemEntity(world,
+							pos.getX() + 0.5d,
+							pos.getY() + 0.5d,
+							pos.getZ() + 0.5d,
+							lkb.stack));
+					handler.remove(lkb.id);
+				});
 	}
 }


### PR DESCRIPTION
This changes bugfixes two major problems related to doors:
1. Locks falling from doors when the door its opened, This was due to improper state synchronization and client-side rendering glitches. The fix ensures that the lock remains visually and logically attached to the door when it's placed.
2. Door opening briefly with a lock – Doors with locks could still be opened for a split second due to client-side prediction and event ordering. The new DoorMixin implementation cancels the open state if a lock is detected, ensuring the door remains closed both visually and functionally when locked.
These changes improve both server-side logic and client-side consistency, resulting in a much more reliable lock behavior across all door interactions.